### PR TITLE
Track visits

### DIFF
--- a/_includes/tracking.html
+++ b/_includes/tracking.html
@@ -3,6 +3,19 @@
   _paq.push(['setDomains', ['*.quaidorsay.fr','ambanum.github.io']]);
   _paq.push(['trackPageView']);
   _paq.push(['enableLinkTracking']);
+  _paq.push([function() {
+    var self = this;
+    function getOriginalVisitorCookieTimeout() {
+      var now = new Date(),
+        nowTs = Math.round(now.getTime() / 1000),
+        visitorInfo = self.getVisitorInfo();
+      var createTs = parseInt(visitorInfo[2]);
+      var cookieTimeout = 13 * 30 * 24 * 60 * 60; // 13 months in seconds
+      var originalTimeout = createTs + cookieTimeout - nowTs;
+      return originalTimeout;
+    }
+    this.setVisitorCookieTimeout(getOriginalVisitorCookieTimeout());
+  }]);
   (function() {
     var u='https://stats.data.gouv.fr/';
     _paq.push(['setTrackerUrl', u+'piwik.php']);

--- a/_includes/tracking.html
+++ b/_includes/tracking.html
@@ -24,3 +24,4 @@
     g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
   })();
 </script>
+<noscript><img src="https://stats.data.gouv.fr/matomo.php?idsite=89&rec=1" style="border:0;" alt="" /></noscript>

--- a/_includes/tracking.html
+++ b/_includes/tracking.html
@@ -1,0 +1,13 @@
+<script type="text/javascript">
+  var _paq = window._paq || [];
+  _paq.push(['setDomains', ['*.quaidorsay.fr','ambanum.github.io']]);
+  _paq.push(['trackPageView']);
+  _paq.push(['enableLinkTracking']);
+  (function() {
+    var u='https://stats.data.gouv.fr/';
+    _paq.push(['setTrackerUrl', u+'piwik.php']);
+    _paq.push(['setSiteId', '89']);
+    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+    g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+  })();
+</script>

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -3,16 +3,16 @@
 	<head>
 		<meta charset="UTF-8">
 		<meta http-equiv="X-UA-Compatible" content="IE=Edge">
-				{% if page.description %}
-						<meta name="description" content="{{ page.description }}">
-				{% endif %}
+		{% if page.description %}
+		<meta name="description" content="{{ page.description }}">
+		{% endif %}
 
-				<title>Fight against disinformation</title>
+		<title>Fight against disinformation</title>
 
-				<link rel="stylesheet" href="{{ '/assets/css/landing.css' | absolute_url }}">
-				<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.4/css/bulma.min.css" integrity="sha256-8B1OaG0zT7uYA572S2xOxWACq9NXYPQ+U5kHPV1bJN4=" crossorigin="anonymous" />
-				<meta name="viewport" content="width=device-width, initial-scale=1">
-		</head>
+		<link rel="stylesheet" href="{{ '/assets/css/landing.css' | absolute_url }}">
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.4/css/bulma.min.css" integrity="sha256-8B1OaG0zT7uYA572S2xOxWACq9NXYPQ+U5kHPV1bJN4=" crossorigin="anonymous" />
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+	</head>
 
 	<body class="landing">
 		{{ content }}

--- a/_layouts/landing.html
+++ b/_layouts/landing.html
@@ -16,5 +16,7 @@
 
 	<body class="landing">
 		{{ content }}
+
+		{% include tracking.html %}
 	</body>
 </html>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,7 @@
+---
+layout: default
+---
+
+{{ content }}
+
+{% include tracking.html %}

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -96,6 +96,8 @@ nav_exclude: true
 					<a href="https://github.com/ambanum/disinformation-encyclopedia">Source Code</a>
 					&nbsp;|&nbsp;
 					<a href="mailto:matti.schneider@diplomatie.gouv.fr">Contact us</a>
+					&nbsp;|&nbsp;
+					<a href="/tracking.html">Analytics and privacy</a>
 				</div>
 			</div>
 			<div class="columns">

--- a/_pages/tracking.html
+++ b/_pages/tracking.html
@@ -1,0 +1,18 @@
+---
+layout: page
+permalink: /tracking
+nav_exclude: true
+---
+
+<section>
+	<h1>Analytics and privacy</h1>
+
+	<p>When you visit this website, we leave a small text file (a “cookie”) on your computer. This allows us to measure how many visits we’ve had and which pages are most viewed.</p>
+	<iframe class="optout" src="https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=en"></iframe>
+
+	<h3>Why doesn’t this website show a consent banner for cookies?</h3>
+	<p>The tracking software we use, <a href="https://www.matomo.org">Matomo</a>, is open-source, self-managed, and set up to properly anonymize your data and is thus exempt from prior consent according to the French data protection authority <abbr title="Commission Nationale de l'Informatique et des Libertés">CNIL</abbr>’s <a href="https://www.cnil.fr/fr/solutions-pour-la-mesure-daudience" hreflang="fr-FR">recommendations</a>.</p>
+
+	<h3>I contribute to your data, can I access it?</h3>
+	<p>Of course! The analytics data for this website are publicly available on <a href="https://stats.data.gouv.fr/index.php?module=CoreHome&action=index&idSite=89&period=range&date=previous30">stats.data.gouv.fr</a></p>
+</section>

--- a/_pages/tracking.html
+++ b/_pages/tracking.html
@@ -8,7 +8,7 @@ nav_exclude: true
 	<h1>Analytics and privacy</h1>
 
 	<p>When you visit this website, we leave a small text file (a “cookie”) on your computer. This allows us to measure how many visits we’ve had and which pages are most viewed.</p>
-	<iframe class="optout" src="https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=en"></iframe>
+	<iframe src="https://stats.data.gouv.fr/index.php?module=CoreAdminHome&action=optOut&language=en&backgroundColor=&fontColor=&fontSize=&fontFamily=helvetica%20neue"></iframe>
 
 	<h3>Why doesn’t this website show a consent banner for cookies?</h3>
 	<p>The tracking software we use, <a href="https://www.matomo.org">Matomo</a>, is open-source, self-managed, and set up to properly anonymize your data and is thus exempt from prior consent according to the French data protection authority <abbr title="Commission Nationale de l'Informatique et des Libertés">CNIL</abbr>’s <a href="https://www.cnil.fr/fr/solutions-pour-la-mesure-daudience" hreflang="fr-FR">recommendations</a>.</p>

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1,3 +1,7 @@
+abbr[title] {
+	text-decoration: none;
+}
+
 .error-page {
 	margin: 10px auto;
 	max-width: 600px;

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -2,7 +2,7 @@
 	margin: 10px auto;
 	max-width: 600px;
 	text-align: center;
-	
+
 	h1 {
 		margin: 30px 0;
 		font-size: 4em;
@@ -17,4 +17,9 @@
 
 .site-footer {
 	display: none;
+}
+
+iframe {
+	width: 100%;
+	border: none;
 }


### PR DESCRIPTION
- Add Matomo tracking code, abiding by the [CNIL’s recommendations](https://www.cnil.fr/sites/default/files/typo/document/Configuration_piwik.pdf) to allow for opt-out rather than opt-in tracking.
- Add a privacy information page with opt-out option.

Data can be found here: https://stats.data.gouv.fr/index.php?module=CoreHome&action=index&idSite=89&period=range&date=last30#?idSite=89&period=range&date=last30&category=Dashboard_Dashboard&subcategory=1

Footer addition:
![Capture d’écran 2019-05-09 à 11 34 27](https://user-images.githubusercontent.com/222463/57443553-9daeb980-724e-11e9-912a-359d0a75b156.png)

Privacy page:
![Capture d’écran 2019-05-09 à 11 34 38](https://user-images.githubusercontent.com/222463/57443554-9daeb980-724e-11e9-875d-84dd4b53efcf.png)